### PR TITLE
Some tweaks to the look of posts

### DIFF
--- a/_includes/post-cards.html
+++ b/_includes/post-cards.html
@@ -10,11 +10,7 @@
             <h3 class="card-title text-center">{{ post.title }}</h3>
 
             <p class="card-text text-center">
-                {% if post.description %}
-                    {{ post.description }}
-                {% else %}
-                    {{ post.content | strip_html | truncatewords: 50 }}
-                {% endif %}
+                {{ post.content | strip_html | truncatewords: 50 }}
             </p>
 
             <p class="card-text text-center read-more">

--- a/_includes/post_categories.html
+++ b/_includes/post_categories.html
@@ -1,0 +1,16 @@
+{% if page.categories.size > 0 %}
+  {% assign ordered_categories = page.categories | sort %}
+  <div class="category-tags d-flex flex-wrap justify-content-center">
+    {% for category in ordered_categories %}
+      {% capture capitalized_category %}
+        {% for word in category %}
+          {{ word | capitalize }}
+        {% endfor %}
+      {% endcapture %}
+      {% assign categories_link = site.url | append: site.baseurl | append: '/categories.html' %}
+      <a class="card-link my-2 px-3 py-2" href="{{ categories_link }}#{{ category | slugify }}">
+        <span>{{ capitalized_category }}</span>
+      </a>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,13 +15,31 @@ layout: default
       <h5 class="post-title text-center">{{ page.description }}</h5>
       <div class="post-meta text-center">
 
-        {% if page.author %}
+        {% if page.author.size > 1 or page.editor.size > 0 %}
           {% for author in page.author %}
-            <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
-              {{ author }} -
-            </span>
-            {% if forloop.last == false %}, {% endif %}
+            {% if page.editor.size == 0 %}
+              {% if forloop.last == false or forloop.first == true %}
+                <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                  {{ author | append: ", " }}
+                </span>
+              {% endif %}
+            {% else %}
+              <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                {{ author | append: ", " }}
+              </span>
+            {% endif %}
           {% endfor %}
+          {% if page.editor.size > 0 %}
+            <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+              edited by
+            </span>
+            {% for editor in page.editor %}
+              <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                {{ editor }}
+              </span>
+              {% if forloop.last == false %}{{ sep }}{% endif %}
+            {% endfor %}
+          {% endif %} -
         {% endif %}
 
         {% assign date_format = site.date_format | default: "%b %d, %Y" %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,7 @@ layout: default
   <div class="row post-header">
     <div class="col">
       <h1 class="post-title text-center">{{ page.title }}</h1>
+      <h5 class="post-title text-center">{{ page.description }}</h5>
       <div class="post-meta text-center">
 
         {% if page.author %}
@@ -33,6 +34,17 @@ layout: default
           <time class="post-metadata" datetime="{{ mdate }}" itemprop="dateModified">
             {{ mdate | date: date_format }}
           </time>
+        
+        <!-- SUGGEST AN EDIT -->
+        {% if site.repository and site.default_branch %}
+          |{% assign edit_link = "https://github.com/" | append: site.repository | append: "/edit/" | append: site.default_branch | append: "/" | append: page.path %}
+          <a href="{{edit_link}}"><i class="fas fa-edit"></i> Suggest an edit</a>
+          <br>
+        {% endif %}
+
+        <!-- POST CATEGORIES -->
+        {% include post_categories.html %}
+        
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
Following are the changes introduced in this fork of [jekyll-theme-cadre](https://github.com/slee981/jekyll-theme-cadre):

1. Post description, if present in the front matter, is displayed below the post title.

2. Editors can be mentioned in front matter as a string or list: 

      `editor = "<editor>"` or,
      `editor = ["<editor_1>", "<editor_2>", ...]`
      
Authors and editors are automatically displayed 'nicely' in the post metadata as,

      <author_1>, <author_2>, ... , edited by <editor_1>, <editor_2>, ...

3. Post categories are displayed alphabetically as tags below post metadata. The tags anchor to corresponding sections in category.html.

4. Post descriptions do _not_ appear in index.html as they are now displayed in posts.

Here is a preview of the changes mentioned above:

![image](https://user-images.githubusercontent.com/69502869/142738231-3e9e33a0-21e9-4c2d-ab6f-57b375b60b72.png)