### PR TITLE
Some tweaks to the look of posts

### DIFF
--- a/_includes/post-cards.html
+++ b/_includes/post-cards.html
@@ -10,11 +10,7 @@
             <h3 class="card-title text-center">{{ post.title }}</h3>
 
             <p class="card-text text-center">
-                {% if post.description %}
-                    {{ post.description }}
-                {% else %}
-                    {{ post.content | strip_html | truncatewords: 50 }}
-                {% endif %}
+                {{ post.content | strip_html | truncatewords: 50 }}
             </p>
 
             <p class="card-text text-center read-more">

--- a/_includes/post-cards.html
+++ b/_includes/post-cards.html
@@ -8,6 +8,9 @@
     <div class="card my-2 mx-3">
         <div class="card-body p-5">
             <h3 class="card-title text-center">{{ post.title }}</h3>
+            {% if post.description %}
+            <h6 class="card-title text-center">{{ post.description }}</h6>
+            {% endif %}
 
             <p class="card-text text-center">
                 {{ post.content | strip_html | truncatewords: 50 }}
@@ -21,4 +24,3 @@
         </div>
     </div>
 {% endfor %}
-

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,17 +60,17 @@ layout: default
         
         <!-- POST CATEGORIES DISPLAYED AS CATEGORY TAGS -->
         {% if page.categories.size > 0 %}
-          {% assign ordered_categories = page.categories | sort %}
           <div class="category-tags d-flex flex-wrap justify-content-center">
-            {% for category in ordered_categories %}
-              {% capture capitalized_category %}
-                {% for word in category %}
-                  {{ word | capitalize }}
-                {% endfor %}
+            {% for category in page.categories %}
+              {% assign anchor_url = site.url | append: site.baseurl | append: '/categories.html' %}
+              {% assign category_words = category | split: ' ' %}
+              {% capture capitalized_category_name %}
+              {% for word in category_words %}
+                {{ word | capitalize }}
+              {% endfor %}
               {% endcapture %}
-              {% assign categories_link = site.url | append: site.baseurl | append: '/categories.html' %}
-              <a class="card-link my-2 px-3 py-2" href="{{ categories_link }}#{{ category | slugify }}">
-                <span>{{ capitalized_category }}</span>
+              <a class="card-link my-2 px-3 py-2" href="{{ anchor_url }}#{{ category | slugify }}">
+                {{ capitalized_category_name }}
               </a>
             {% endfor %}
           </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,15 +12,35 @@ layout: default
   <div class="row post-header">
     <div class="col">
       <h1 class="post-title text-center">{{ page.title }}</h1>
+      <h5 class="post-title text-center">{{ page.description }}</h5>
       <div class="post-meta text-center">
 
-        {% if page.author %}
+        <!-- AUTHORS AND EDITORS -->
+        {% if page.author.size > 1 or page.editor.size > 0 %}
           {% for author in page.author %}
-            <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
-              {{ author }} -
-            </span>
-            {% if forloop.last == false %}, {% endif %}
+            {% if page.editor.size == 0 %}
+              {% if forloop.last == false or forloop.first == true %}
+                <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                  {{ author | append: ", " }}
+                </span>
+              {% endif %}
+            {% else %}
+              <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                {{ author | append: ", " }}
+              </span>
+            {% endif %}
           {% endfor %}
+          {% if page.editor.size > 0 %}
+            <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+              edited by
+            </span>
+            {% for editor in page.editor %}
+              <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                {{ editor }}
+              </span>
+              {% if forloop.last == false %}{{ sep }}{% endif %}
+            {% endfor %}
+          {% endif %} -
         {% endif %}
 
         {% assign date_format = site.date_format | default: "%b %d, %Y" %}
@@ -34,6 +54,25 @@ layout: default
             {{ mdate | date: date_format }}
           </time>
         {% endif %}
+        
+        <!-- POST CATEGORIES DISPLAYED AS CATEGORY TAGS -->
+        {% if page.categories.size > 0 %}
+          {% assign ordered_categories = page.categories | sort %}
+          <div class="category-tags d-flex flex-wrap justify-content-center">
+            {% for category in ordered_categories %}
+              {% capture capitalized_category %}
+                {% for word in category %}
+                  {{ word | capitalize }}
+                {% endfor %}
+              {% endcapture %}
+              {% assign categories_link = site.url | append: site.baseurl | append: '/categories.html' %}
+              <a class="card-link my-2 px-3 py-2" href="{{ categories_link }}#{{ category | slugify }}">
+                <span>{{ capitalized_category }}</span>
+              </a>
+            {% endfor %}
+          </div>
+        {% endif %}
+        
       </div>
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,7 +40,10 @@ layout: default
               </span>
               {% if forloop.last == false %}{{ sep }}{% endif %}
             {% endfor %}
-          {% endif %} -
+          {% endif %}
+          <span class="post-metadata" itemprop="author" itemscope itemtype="http://schema.org/Person">
+            -
+          </span>
         {% endif %}
 
         {% assign date_format = site.date_format | default: "%b %d, %Y" %}

--- a/_posts/2020-12-31-sample-of-options.md
+++ b/_posts/2020-12-31-sample-of-options.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Sample of Post Options
-author: Songzi Vong, updated by Stephen Lee
+author: Songzi Vong
+editor: Stephen Lee
 categories: [general, tutorial, jekyll]
 toc: true
 katex: true


### PR DESCRIPTION
## Changes

1. Post description, if present in front matter, is displayed below the post title.

2. Editors can be mentioned in front matter as a list: 

      `editor = ["<editor_1>" (, "<editor_2>", ...)]`
      
If the post has editors, `author` should be declared in similar manner as a list (_not_ as a string) for the site to build correctly.
      
Authors and editors are automatically displayed 'nicely' in the post metadata as,

      <author_1>, <author_2>, ... , edited by <editor_1>, <editor_2>, ...

3. Post categories are displayed alphabetically as tags below post metadata. These anchor to corresponding sections in category.html.

4. Post description _and_ truncated post content are shown in post-cards.html.

## Screenshots

1. Sample post

![image](https://user-images.githubusercontent.com/69502869/145706587-c6ee85c3-e2d0-46ff-9a60-1fb70e7f98d5.png)

2. Homepage

![index.html](https://user-images.githubusercontent.com/69502869/142740399-17636f97-2a80-4292-833b-d7db6b358622.png)